### PR TITLE
Cf details training

### DIFF
--- a/BangazonWorkforce/BangazonWorkforce.csproj
+++ b/BangazonWorkforce/BangazonWorkforce.csproj
@@ -13,4 +13,9 @@
 
   </ItemGroup>
 
+
+  <ItemGroup>
+    <Folder Include="Models\ViewModels\" />
+  </ItemGroup>
+
 </Project>

--- a/BangazonWorkforce/Controllers/TrainingProgramController.cs
+++ b/BangazonWorkforce/Controllers/TrainingProgramController.cs
@@ -70,6 +70,49 @@ namespace BangazonWorkforce.Controllers
             }
         }
 
+        public ActionResult List()
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+            SELECT t.Id,
+                t.Name,
+                t.StartDate,
+                t.EndDate,
+                t.MaxAttendees
+            FROM TrainingProgram t
+        ";
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    List<TrainingProgram> trainingPrograms = new List<TrainingProgram>();
+                    while (reader.Read())
+                    {
+
+                        TrainingProgram trainingProgram = new TrainingProgram
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                            EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                            MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
+                        };
+                        DateTime now = DateTime.Now;
+                        if ((DateTime.Compare(trainingProgram.StartDate, now) < 0))
+                        {
+                            trainingPrograms.Add(trainingProgram);
+                        }
+                    }
+
+                    reader.Close();
+
+                    return View(trainingPrograms);
+                }
+            }
+        }
+
         // GET: TrainingProgram/Details/5
         public ActionResult Details(int id)
         {
@@ -120,6 +163,7 @@ namespace BangazonWorkforce.Controllers
                         }
                     }
                     reader.Close();
+
                     return View(trainingToDisplay);
                 }
             }
@@ -192,8 +236,14 @@ namespace BangazonWorkforce.Controllers
                     }
 
                     reader.Close();
-
-                    return View(training);
+                    DateTime now = DateTime.Now;
+                    if (!(DateTime.Compare(training.EndDate, now) < 0))
+                    {
+                        return View(training);
+                    }
+                    else {
+                        return RedirectToAction(nameof(Index));
+                    }
                 }
             }
         }

--- a/BangazonWorkforce/Controllers/TrainingProgramController.cs
+++ b/BangazonWorkforce/Controllers/TrainingProgramController.cs
@@ -83,7 +83,7 @@ namespace BangazonWorkforce.Controllers
                                         t.MaxAttendees, e.Id AS 'Employee Id', e.FirstName, 
                                         e.LastName, e.DepartmentId FROM EmployeeTraining et
                                         JOIN Employee e on et.EmployeeId = e.id 
-                                        JOIN TrainingProgram t on et.TrainingProgramId = t.id";
+                                        JOIN TrainingProgram t on et.TrainingProgramId = t.id WHERE t.Id = @id";
                                        
 
                     cmd.Parameters.Add(new SqlParameter("@id", id));
@@ -98,11 +98,11 @@ namespace BangazonWorkforce.Controllers
                         {
                             TrainingProgram training = new TrainingProgram
                             {
-                                Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                                Id = reader.GetInt32(reader.GetOrdinal("trainingId")),
                                 Name = reader.GetString(reader.GetOrdinal("Name")),
                                 StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
                                 EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
-                                MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
+                                MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees")),
                             };
                             
                             trainingToDisplay = training;

--- a/BangazonWorkforce/Controllers/TrainingProgramController.cs
+++ b/BangazonWorkforce/Controllers/TrainingProgramController.cs
@@ -10,6 +10,9 @@ using Microsoft.Extensions.Configuration;
 
 namespace BangazonWorkforce.Controllers
 {
+    ///  Controller for training programs. Full crud, but there's a second GET all for past trainings. 
+    ///  By Connor FitzGerald
+    
     public class TrainingProgramsController : Controller
     {
         private readonly IConfiguration _config;
@@ -26,7 +29,8 @@ namespace BangazonWorkforce.Controllers
                 return new SqlConnection(_config.GetConnectionString("DefaultConnection"));
             }
         }
-        // GET: TrainingPrograms
+        // GET ALL TRAINING PROGRAMS THAT START AFTER TODAY'S DATE
+       
         public ActionResult Index()
         {
             using (SqlConnection conn = Connection)
@@ -56,6 +60,7 @@ namespace BangazonWorkforce.Controllers
                             EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
                             MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
                             };
+                        ///This will only add trainings to the display list if the start date is after today
                             DateTime now = DateTime.Now;
                             if (!(DateTime.Compare(trainingProgram.StartDate, now) < 0))
                             {
@@ -70,6 +75,7 @@ namespace BangazonWorkforce.Controllers
             }
         }
 
+        //This is a list of past trainings
         public ActionResult List()
         {
             using (SqlConnection conn = Connection)
@@ -99,6 +105,7 @@ namespace BangazonWorkforce.Controllers
                             EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
                             MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
                         };
+                        //Only adds trainings that have already started
                         DateTime now = DateTime.Now;
                         if ((DateTime.Compare(trainingProgram.StartDate, now) < 0))
                         {
@@ -149,6 +156,7 @@ namespace BangazonWorkforce.Controllers
                                 Employees = new List<Employee>()
                             };
                         };
+                        //adds an employee if it exists to the trainings employee list
                         if (!reader.IsDBNull(reader.GetOrdinal("Employee Id")))
                         {
                             Employee employee = new Employee()
@@ -236,6 +244,8 @@ namespace BangazonWorkforce.Controllers
                     }
 
                     reader.Close();
+                    //hopefully makes it so you can't edit past trainings 
+                    //but there shouldn't be a way to naturally navigate to edit for a past training
                     DateTime now = DateTime.Now;
                     if (!(DateTime.Compare(training.EndDate, now) < 0))
                     {
@@ -255,6 +265,7 @@ namespace BangazonWorkforce.Controllers
         {
           using (SqlConnection conn = Connection)
                 {
+                //validates that the end date is not earlier than the start date
                     if (ModelState.IsValid)
                     {
                         conn.Open();

--- a/BangazonWorkforce/Controllers/TrainingProgramController.cs
+++ b/BangazonWorkforce/Controllers/TrainingProgramController.cs
@@ -73,7 +73,58 @@ namespace BangazonWorkforce.Controllers
         // GET: TrainingProgram/Details/5
         public ActionResult Details(int id)
         {
-            return View();
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @" SELECT t.Id as 'trainingId', 
+                                        t.Name, t.StartDate, t.EndDate, 
+                                        t.MaxAttendees, e.Id AS 'Employee Id', e.FirstName, 
+                                        e.LastName, e.DepartmentId FROM EmployeeTraining et
+                                        JOIN Employee e on et.EmployeeId = e.id 
+                                        JOIN TrainingProgram t on et.TrainingProgramId = t.id";
+                                       
+
+                    cmd.Parameters.Add(new SqlParameter("@id", id));
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    TrainingProgram trainingToDisplay = null;
+                    int counter = 0;
+
+                    while (reader.Read())
+                    {
+                        if (counter < 1)
+                        {
+                            TrainingProgram training = new TrainingProgram
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                                Name = reader.GetString(reader.GetOrdinal("Name")),
+                                StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                                EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                                MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees"))
+                            };
+                            
+                            trainingToDisplay = training;
+                            counter++;
+                        };
+                        Employee employee = new Employee
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Employee Id")),
+                            FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                            LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                            DepartmentId = reader.GetInt32(reader.GetOrdinal("DepartmentId"))
+                        };
+
+                        if (!trainingToDisplay.Employees.Any(e => e.Id == employee.Id))
+                        {
+                            trainingToDisplay.Employees.Add(employee);
+                        }
+                    }
+                    reader.Close();
+                    return View(trainingToDisplay);
+                }
+            }
         }
 
         // GET: TrainingProgram/Create

--- a/BangazonWorkforce/Controllers/TrainingProgramController.cs
+++ b/BangazonWorkforce/Controllers/TrainingProgramController.cs
@@ -82,42 +82,40 @@ namespace BangazonWorkforce.Controllers
                                         t.Name, t.StartDate, t.EndDate, 
                                         t.MaxAttendees, e.Id AS 'Employee Id', e.FirstName, 
                                         e.LastName, e.DepartmentId FROM EmployeeTraining et
-                                        JOIN Employee e on et.EmployeeId = e.id 
-                                        JOIN TrainingProgram t on et.TrainingProgramId = t.id WHERE t.Id = @id";
+                                        FULL JOIN Employee e on et.EmployeeId = e.id 
+                                        FULL JOIN TrainingProgram t on et.TrainingProgramId = t.id WHERE t.Id = @id";
                                        
 
                     cmd.Parameters.Add(new SqlParameter("@id", id));
                     SqlDataReader reader = cmd.ExecuteReader();
 
                     TrainingProgram trainingToDisplay = null;
-                    int counter = 0;
+                   
 
                     while (reader.Read())
                     {
-                        if (counter < 1)
+                        if (trainingToDisplay == null)
                         {
-                            TrainingProgram training = new TrainingProgram
+                            trainingToDisplay = new TrainingProgram
                             {
                                 Id = reader.GetInt32(reader.GetOrdinal("trainingId")),
                                 Name = reader.GetString(reader.GetOrdinal("Name")),
                                 StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
                                 EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
                                 MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees")),
+                                Employees = new List<Employee>()
                             };
-                            
-                            trainingToDisplay = training;
-                            counter++;
                         };
-                        Employee employee = new Employee
+                        if (!reader.IsDBNull(reader.GetOrdinal("Employee Id")))
                         {
-                            Id = reader.GetInt32(reader.GetOrdinal("Employee Id")),
-                            FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
-                            LastName = reader.GetString(reader.GetOrdinal("LastName")),
-                            DepartmentId = reader.GetInt32(reader.GetOrdinal("DepartmentId"))
-                        };
-
-                        if (!trainingToDisplay.Employees.Any(e => e.Id == employee.Id))
-                        {
+                            Employee employee = new Employee()
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("Employee Id")),
+                                FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                                LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                                DepartmentId = reader.GetInt32(reader.GetOrdinal("DepartmentId"))
+                               
+                            };
                             trainingToDisplay.Employees.Add(employee);
                         }
                     }

--- a/BangazonWorkforce/Controllers/TrainingProgramController.cs
+++ b/BangazonWorkforce/Controllers/TrainingProgramController.cs
@@ -154,38 +154,93 @@ namespace BangazonWorkforce.Controllers
                         cmd.ExecuteNonQuery();
 
                         return RedirectToAction(nameof(Index));
-                    }
-                }
-                else
-                {
+                        }
+                    }else{
                     return View();
-                }
+                    }
                  
-            }
-            }        
+                }
+        }
 
-        // GET: TrainingProgram/Edit/5
         public ActionResult Edit(int id)
         {
-            return View();
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+            SELECT 
+                t.Id, t.Name, t.StartDate, t.EndDate, t.MaxAttendees
+            FROM TrainingProgram t 
+            WHERE Id = @id";
+                    cmd.Parameters.Add(new SqlParameter("@id", id));
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    TrainingProgram training = null;
+                    if (reader.Read())
+                    {
+                        training = new TrainingProgram
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                            EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                            MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees")),
+
+                        };
+                    }
+
+                    reader.Close();
+
+                    return View(training);
+                }
+            }
         }
 
-        // POST: TrainingProgram/Edit/5
+        // POST: Cohorts/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Edit(int id, IFormCollection collection)
+        public ActionResult Edit(int id, TrainingProgram training)
         {
-            try
-            {
-                // TODO: Add update logic here
+          using (SqlConnection conn = Connection)
+                {
+                    if (ModelState.IsValid)
+                    {
+                        conn.Open();
+                        using (SqlCommand cmd = conn.CreateCommand())
+                        {
+                            cmd.CommandText = @"UPDATE TrainingProgram
+                                            SET Name = @Name, 
+                                            StartDate = @StartDate,
+                                            EndDate = @EndDate,
+                                            MaxAttendees = @MaxAttendees
+                                            WHERE Id = @id";
+                            cmd.Parameters.Add(new SqlParameter("@Name", training.Name));
+                            cmd.Parameters.Add(new SqlParameter("@StartDate", training.StartDate));
+                            cmd.Parameters.Add(new SqlParameter("@EndDate", training.EndDate));
+                            cmd.Parameters.Add(new SqlParameter("@MaxAttendees", training.MaxAttendees));
 
-                return RedirectToAction(nameof(Index));
-            }
-            catch
-            {
-                return View();
-            }
-        }
+                            cmd.Parameters.Add(new SqlParameter("@id", id));
+
+                            training = new TrainingProgram();
+
+                            int rowsAffected = cmd.ExecuteNonQuery();
+
+                            return RedirectToAction(nameof(Index));
+
+                        }
+                    }
+                    else
+                    {
+                        return View(training);
+                    }
+
+                    }
+                }
+            
+                
+         
 
         public ActionResult Delete(int id)
         {

--- a/BangazonWorkforce/Models/TrainingProgram.cs
+++ b/BangazonWorkforce/Models/TrainingProgram.cs
@@ -20,7 +20,7 @@ namespace BangazonWorkforce.Models
         [Display(Name = "Max Attendees")]
         public int MaxAttendees { get; set; }
         public List<Employee> Employees { get; set; } = new List<Employee>();
-
+        //This ensures that a new training program must have an end date later than the start date
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
             if  ((DateTime.Compare(EndDate, StartDate) < 0))

--- a/BangazonWorkforce/Models/TrainingProgram.cs
+++ b/BangazonWorkforce/Models/TrainingProgram.cs
@@ -11,10 +11,13 @@ namespace BangazonWorkforce.Models
     {
 
         public int Id { get; set; }
-
+        [Display(Name = "Training Name")]
         public string Name { get; set; }
+        [Display(Name = "Start Date")]
         public DateTime StartDate { get; set; }
+        [Display(Name = "End Date")]
         public DateTime EndDate { get; set; }
+        [Display(Name = "Max Attendees")]
         public int MaxAttendees { get; set; }
         public List<Employee> Employees { get; set; } = new List<Employee>();
 

--- a/BangazonWorkforce/Views/TrainingPrograms/Create.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Create.cshtml
@@ -43,7 +43,7 @@
 </div>
 
 <div>
-    <a asp-action="Index">Back to List</a>
+    <a asp-action="Index">Back to upcoming trainings</a>
 </div>
 
 @section Scripts {

--- a/BangazonWorkforce/Views/TrainingPrograms/Delete.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Delete.cshtml
@@ -45,6 +45,6 @@
     
     <form asp-action="Delete">
         <input type="submit" value="Delete" class="btn btn-danger" /> |
-        <a asp-action="Index">Back to List</a>
+        <a asp-action="Index">Back to upcoming trainings</a>
     </form>
 </div>

--- a/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
@@ -69,6 +69,15 @@
     }
 </div>
 <div>
-    @Html.ActionLink("Edit", "Edit", new {  id = Model.Id }) |
-    <a asp-action="Index">Back to List</a>
+    @if (Model.StartDate > DateTime.Now)
+    {
+        @Html.ActionLink("Edit", "Edit", new { id = Model.Id })
+        <a asp-action="Index">Back to future trainings</a>
+
+    }
+    else
+    {
+     <a asp-action="List">Back to past trainings</a>
+    }
+
 </div>

--- a/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
@@ -71,13 +71,14 @@
 <div>
     @if (Model.StartDate > DateTime.Now)
     {
-        @Html.ActionLink("Edit", "Edit", new { id = Model.Id })
-        <a asp-action="Index">Back to future trainings</a>
+        @Html.ActionLink("Edit |", "Edit", new { id = Model.Id }) 
+        <a asp-action="Index">Back to upcoming trainings</a>
 
     }
     else
     {
-     <a asp-action="List">Back to past trainings</a>
+        <br />
+        <a asp-action="List">Back to past trainings</a>
     }
 
 </div>

--- a/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
@@ -41,26 +41,29 @@
             @Html.DisplayFor(model => model.MaxAttendees)
         </dd>
     </dl>
-    <h4>Currently assigned:</h4>
+
     <hr />
     @if (Model.Employees.Count > 0)
     {
+        <h4>Currently assigned:</h4>
         @foreach (var employee in Model.Employees)
 
         {
-            <dl class="row">
-                <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.Id) </dt>
-                <dd class="col-sm-10"> @Html.DisplayFor(ModelItem => employee.Id)</dd>
-                <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.FirstName)</dt>
-                <dd class="col-sm-10">@Html.DisplayFor(ModelItem => employee.LastName)</dd>
-                <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.DepartmentId)</dt>
-                <dd class="col-sm-10">@Html.DisplayFor(ModelItem => employee.DepartmentId)</dd>
-            </dl>
+<dl class="row">
+    <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.Id) </dt>
+    <dd class="col-sm-10"> @Html.DisplayFor(ModelItem => employee.Id)</dd>
+    <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.FirstName)</dt>
+    <dd class="col-sm-10">@Html.DisplayFor(ModelItem => employee.FirstName)</dd>
+    <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.LastName)</dt>
+    <dd class="col-sm-10">@Html.DisplayFor(ModelItem => employee.LastName)</dd>
+    <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.DepartmentId)</dt>
+    <dd class="col-sm-10">@Html.DisplayFor(ModelItem => employee.DepartmentId)</dd>
+</dl>
         }
     }
     else
     {
-    <p>No employees currently registered!</p>
+        <p>No employees currently registered!</p>
 
     }
 </div>

--- a/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
@@ -7,7 +7,7 @@
 <h1>Details</h1>
 
 <div>
-    <h4>TrainingProgram</h4>
+    <h4>Training Program</h4>
     <hr />
     <dl class="row">
         <dt class="col-sm-2">
@@ -45,7 +45,7 @@
     <hr />
     @if (Model.Employees.Count > 0)
     {
-        <h4>Currently registered:</h4>
+        <h4>Registered:</h4>
         @foreach (var employee in Model.Employees)
 
         {
@@ -64,7 +64,7 @@
     }
     else
     {
-        <h4>No employees currently registered!</h4>
+        <h4>No employees registered!</h4>
 
     }
 </div>

--- a/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
@@ -1,0 +1,70 @@
+﻿@model BangazonWorkforce.Models.TrainingProgram
+
+@{
+    ViewData["Title"] = "Details";
+}
+
+<h1>Details</h1>
+
+<div>
+    <h4>TrainingProgram</h4>
+    <hr />
+    <dl class="row">
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Id)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Id)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.Name)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.Name)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.StartDate)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.StartDate)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.EndDate)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.EndDate)
+        </dd>
+        <dt class="col-sm-2">
+            @Html.DisplayNameFor(model => model.MaxAttendees)
+        </dt>
+        <dd class="col-sm-10">
+            @Html.DisplayFor(model => model.MaxAttendees)
+        </dd>
+    </dl>
+    <h4>Currently assigned:</h4>
+    <hr />
+    @if (Model.Employees.Count > 0)
+    {
+        @foreach (var employee in Model.Employees)
+
+        {
+            <dl class="row">
+                <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.Id) </dt>
+                <dd class="col-sm-10"> @Html.DisplayFor(ModelItem => employee.Id)</dd>
+                <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.FirstName)</dt>
+                <dd class="col-sm-10">@Html.DisplayFor(ModelItem => employee.LastName)</dd>
+                <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.DepartmentId)</dt>
+                <dd class="col-sm-10">@Html.DisplayFor(ModelItem => employee.DepartmentId)</dd>
+            </dl>
+        }
+    }
+    else
+    {
+    <p>No employees currently registered!</p>
+
+    }
+</div>
+<div>
+    @Html.ActionLink("Edit", "Edit", new {  id = Model.Id }) |
+    <a asp-action="Index">Back to List</a>
+</div>

--- a/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Details.cshtml
@@ -45,7 +45,7 @@
     <hr />
     @if (Model.Employees.Count > 0)
     {
-        <h4>Currently assigned:</h4>
+        <h4>Currently registered:</h4>
         @foreach (var employee in Model.Employees)
 
         {
@@ -59,11 +59,12 @@
     <dt class="col-sm-2">@Html.DisplayNameFor(ModelItem => employee.DepartmentId)</dt>
     <dd class="col-sm-10">@Html.DisplayFor(ModelItem => employee.DepartmentId)</dd>
 </dl>
+    <hr />
         }
     }
     else
     {
-        <p>No employees currently registered!</p>
+        <h4>No employees currently registered!</h4>
 
     }
 </div>

--- a/BangazonWorkforce/Views/TrainingPrograms/Edit.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Edit.cshtml
@@ -1,0 +1,48 @@
+﻿@model BangazonWorkforce.Models.TrainingProgram
+
+@{
+    ViewData["Title"] = "Edit";
+}
+
+<h1>Edit</h1>
+
+<h4>TrainingProgram</h4>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        <form asp-action="Edit">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+            <div class="form-group">
+                <label asp-for="Name" class="control-label"></label>
+                <input asp-for="Name" class="form-control" />
+                <span asp-validation-for="Name" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="StartDate" class="control-label"></label>
+                <input asp-for="StartDate" class="form-control" />
+                <span asp-validation-for="StartDate" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="EndDate" class="control-label"></label>
+                <input asp-for="EndDate" class="form-control" />
+                <span asp-validation-for="EndDate" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <label asp-for="MaxAttendees" class="control-label"></label>
+                <input asp-for="MaxAttendees" class="form-control" />
+                <span asp-validation-for="MaxAttendees" class="text-danger"></span>
+            </div>
+            <div class="form-group">
+                <input type="submit" value="Save" class="btn btn-primary" />
+            </div>
+        </form>
+    </div>
+</div>
+
+<div>
+    <a asp-action="Index">Back to List</a>
+</div>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/BangazonWorkforce/Views/TrainingPrograms/Edit.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Edit.cshtml
@@ -6,7 +6,7 @@
 
 <h1>Edit</h1>
 
-<h4>TrainingProgram</h4>
+<h4>Training Program</h4>
 <hr />
 <div class="row">
     <div class="col-md-4">
@@ -40,7 +40,7 @@
 </div>
 
 <div>
-    <a asp-action="Index">Back to List</a>
+    <a asp-action="Index">Back to upcoming trainings</a>
 </div>
 
 @section Scripts {

--- a/BangazonWorkforce/Views/TrainingPrograms/Index.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Index.cshtml
@@ -6,7 +6,7 @@
     <p>
         <a asp-action="Create">Create New</a>
     </p>
-<h1>Current:</h1>
+<h1>Upcoming trainings</h1>
 
 
 <table class="table">

--- a/BangazonWorkforce/Views/TrainingPrograms/Index.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/Index.cshtml
@@ -3,12 +3,11 @@
 @{
     ViewData["Title"] = "Index";
 }
-    <p>
-        <a asp-action="Create">Create New</a>
-    </p>
+
 <h1>Upcoming trainings</h1>
-
-
+<p>
+    <a asp-action="Create">Create New</a>
+</p>
 <table class="table">
     <thead>
         <tr>
@@ -31,30 +30,31 @@
         </tr>
     </thead>
     <tbody>
-@foreach (var item in Model) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.Id)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.Name)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.StartDate)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.EndDate)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.MaxAttendees)
-            </td>
-            <td>
-                @Html.ActionLink("Edit", "Edit", new {  id=item.Id }) |
-                @Html.ActionLink("Details", "Details", new { id=item.Id }) |
-                @Html.ActionLink("Delete", "Delete", new {  id=item.Id })
-            </td>
-        </tr>
-}
+        @foreach (var item in Model)
+        {
+            <tr>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Id)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.Name)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.StartDate)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.EndDate)
+                </td>
+                <td>
+                    @Html.DisplayFor(modelItem => item.MaxAttendees)
+                </td>
+                <td>
+                    @Html.ActionLink("Edit", "Edit", new { id = item.Id }) |
+                    @Html.ActionLink("Details", "Details", new { id = item.Id }) |
+                    @Html.ActionLink("Delete", "Delete", new { id = item.Id })
+                </td>
+            </tr>
+        }
     </tbody>
 </table>
 

--- a/BangazonWorkforce/Views/TrainingPrograms/List.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/List.cshtml
@@ -1,13 +1,10 @@
 ﻿@model IEnumerable<BangazonWorkforce.Models.TrainingProgram>
 
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "List";
 }
-    <p>
-        <a asp-action="Create">Create New</a>
-    </p>
-<h1>Current:</h1>
 
+<h1>Past trainings</h1>
 
 <table class="table">
     <thead>
@@ -49,15 +46,10 @@
                 @Html.DisplayFor(modelItem => item.MaxAttendees)
             </td>
             <td>
-                @Html.ActionLink("Edit", "Edit", new {  id=item.Id }) |
-                @Html.ActionLink("Details", "Details", new { id=item.Id }) |
-                @Html.ActionLink("Delete", "Delete", new {  id=item.Id })
+                @Html.ActionLink("Details", "Details", new {  id=item.Id }) 
             </td>
         </tr>
 }
     </tbody>
 </table>
-
-<p>
-    <a asp-action="List">See past trainings</a>
-</p>
+<a asp-action="Index">Back to upcoming trainings</a>

--- a/BangazonWorkforce/Views/TrainingPrograms/List.cshtml
+++ b/BangazonWorkforce/Views/TrainingPrograms/List.cshtml
@@ -52,4 +52,4 @@
 }
     </tbody>
 </table>
-<a asp-action="Index">Back to upcoming trainings</a>
+<a asp-action="Index">Upcoming trainings</a>


### PR DESCRIPTION
# Description

Training programs should now have full crud, and a details page. Additionally, the index for trainings (which shows upcoming trainings) should have a link that shows you past trainings. Both should have a details view that shows employees who attended/will attend that training. If a training has already happened, there should be no links to edit or delete that training.


## Related Ticket(s)
Pretty much all of the Training Programs tickets, sans the list

## Steps to Test
Pull this branch down, run your server on it, and navigate to training programs on the nav bar. You should see a list of trainings taking place after today's date(if you don't, create one!)

Each item should have an edit, details, and delete page, all of which *should* work.
Details should also render an edit button in the details view for a particular training.

A link should be at the bottom of the index for trainings for past trainings, which will take you to a list of all the prior ones. 

There should only be a details view for each item in past trainings.

Essentially: full CRUD for upcoming trainings, read-only for past.


# Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
